### PR TITLE
adding a script to run the project

### DIFF
--- a/docs/start.sh
+++ b/docs/start.sh
@@ -1,0 +1,8 @@
+#/bin/bash
+#################################
+# script para iniciar o projeto #
+#################################
+echo "iniciando o jekyll na porta padrão: http://localhost:4000/"
+echo "happy coding!"
+
+bundle exec jekyll serve


### PR DESCRIPTION
ao invés de digitar "bundle exec jekyll serve", agora é só digitar "sh start.sh" no terminal que ele executa esse comando pra gente. 